### PR TITLE
Handle 401 unauthorized & fix possible NullReferenceException

### DIFF
--- a/src/Patreon.Net/PatreonClient.cs
+++ b/src/Patreon.Net/PatreonClient.cs
@@ -141,7 +141,13 @@ namespace Patreon.Net
             int statusCodeNumber = (int)response.StatusCode;
             switch (statusCodeNumber)
             {
-                case 401: { return await RefreshTokenAsync().ConfigureAwait(false); }
+                case 401: 
+                    {
+                        if (await RefreshTokenAsync().ConfigureAwait(false))
+                            return true;
+
+                        throw new PatreonApiException("Unauthorized -- Authentication failed (bad API key, invalid OAuth token, incorrect scopes, etc.)");
+                    }
                 case 404: { return false; }
                 case 410: { throw new PatreonApiException("Gone -- The resource requested has been removed from our servers."); }
                 case 429: { throw new PatreonApiException("Too Many Requests -- Slow down!"); }

--- a/src/Patreon.Net/PatreonClient.cs
+++ b/src/Patreon.Net/PatreonClient.cs
@@ -212,7 +212,7 @@ namespace Patreon.Net
         {
             string endpoint = Endpoints.Campaigns.GetCampaigns(includes);
             var array = await GetAsync<PatreonResourceArray<Campaign, CampaignRelationships>>(endpoint).ConfigureAwait(false);
-            array.PrepareForPaging(endpoint, this);
+            array?.PrepareForPaging(endpoint, this);
             return array;
         }
 
@@ -231,7 +231,7 @@ namespace Patreon.Net
 
             string endpoint = Endpoints.Campaigns.GetCampaigns(includes);
             var array = await GetAsync<PatreonResourceArray<Campaign, CampaignRelationships>>(Endpoints.Page(endpoint, nextPageCursor)).ConfigureAwait(false);
-            array.PrepareForPaging(endpoint, this);
+            array?.PrepareForPaging(endpoint, this);
             return array;
         }
 
@@ -264,7 +264,7 @@ namespace Patreon.Net
 
             string endpoint = Endpoints.Campaigns.GetCampaignMembers(campaignId, includes);
             var array = await GetAsync<PatreonResourceArray<Member, MemberRelationships>>(endpoint).ConfigureAwait(false);
-            array.PrepareForPaging(endpoint, this);
+            array?.PrepareForPaging(endpoint, this);
             return array;
         }
 
@@ -284,7 +284,7 @@ namespace Patreon.Net
 
             string endpoint = Endpoints.Campaigns.GetCampaignMembers(campaignId, includes);
             var array = await GetAsync<PatreonResourceArray<Member, MemberRelationships>>(Endpoints.Page(endpoint, nextPageCursor)).ConfigureAwait(false);
-            array.PrepareForPaging(endpoint, this);
+            array?.PrepareForPaging(endpoint, this);
             return array;
         }
 


### PR DESCRIPTION
Fixes #7, #9 
- Handle 401 unauthorized by properly throwing PatreonApiException if token refresh fails 
- Fix possible NullReferenceException in functions that return resource arrays

