### PR TITLE
Model updates & bump version to 1.0.3

### DIFF
--- a/src/Patreon.Net.Tests/Program.cs
+++ b/src/Patreon.Net.Tests/Program.cs
@@ -16,7 +16,7 @@ namespace Patreon.Net.Tests
 
             // Get Identity
             var user = await client.GetIdentityAsync(Includes.All).ConfigureAwait(false);
-            Console.WriteLine($"Access token identity: {user.FullName} (ID {user.Id})"); Console.WriteLine("\n\n");
+            Console.WriteLine($"Access token identity: {user.FirstName} {user.LastName} ({user.FullName}) (ID {user.Id})"); Console.WriteLine("\n\n");
 
             // Get Campaigns
             var campaigns = await client.GetCampaignsAsync(Includes.All).ConfigureAwait(false);
@@ -34,7 +34,7 @@ namespace Patreon.Net.Tests
             }
             else
             {
-                Console.WriteLine("No campaigns found, exiting"); 
+                Console.WriteLine("No campaigns found, exiting");
                 return;
             }
 
@@ -46,7 +46,7 @@ namespace Patreon.Net.Tests
             {
                 foreach (var tier in tiers)
                     Console.WriteLine($"\tTier {tier.Id}: titled {tier.Title}, worth {tier.AmountCents} cents, has {tier.PatronCount} patrons");
-                
+
                 Console.WriteLine("\n\n");
             }
 
@@ -56,11 +56,10 @@ namespace Patreon.Net.Tests
             if (members != null)
             {
                 Console.WriteLine($"Total of {members.Meta.Pagination.Total} members in campaign {campaignId}");
-                await foreach(var member in members)
+                await foreach (var member in members)
                 {
-                    Console.WriteLine($"\tMember {member.Id}: {member.FullName} ({member.Email}) has paid {member.LifetimeSupportCents} cents total with status {member.PatronStatus}");
-                    if (memberId == null)
-                        memberId = member.Id;
+                    Console.WriteLine($"\tMember \"{member.Id}\" {member.FullName} ({member.Email}): paid {member.LifetimeSupportCents} cents total, status {member.PatronStatus}, is free member? {member.IsFreeTrial}");
+                    memberId ??= member.Id;
                 }
                 Console.WriteLine("\n\n");
             }
@@ -72,11 +71,11 @@ namespace Patreon.Net.Tests
 
             // Get Member by ID
             var singleMember = await client.GetMemberAsync(memberId, Includes.All).ConfigureAwait(false);
-            Console.WriteLine($"Member {singleMember.Id}: {singleMember.FullName} ({singleMember.PatronStatus}) has paid {singleMember.CampaignLifetimeSupportCents} cents total, entitled to {singleMember.Relationships.Tiers?.Length.ToString() ?? "null"} tier(s)");
+            Console.WriteLine($"Member \"{singleMember.Id}\" {singleMember.FullName} ({singleMember.Email}): paid {singleMember.CampaignLifetimeSupportCents} campaign currency, is free member? {singleMember.IsFreeTrial}, status ({singleMember.PatronStatus}), entitled to {singleMember.Relationships.Tiers?.Length.ToString() ?? "null"} tier(s)");
             var entitledTiers = singleMember.Relationships.Tiers;
             if (entitledTiers != null)
             {
-                foreach(var tier in entitledTiers)
+                foreach (var tier in entitledTiers)
                     Console.WriteLine($"\tTier {tier.Id}: Titled {tier.Title} worth {tier.AmountCents} cents");
             }
             else

--- a/src/Patreon.Net/Models/Campaign.cs
+++ b/src/Patreon.Net/Models/Campaign.cs
@@ -172,7 +172,7 @@ namespace Patreon.Net.Models
         /// <summary>
         /// The campaign's goals.
         /// </summary>
-        [JsonProperty("goals")]
+        [JsonProperty("goals"), Obsolete("[DEPRECATED!] The campaign's goals. Will always be empty.")]
         public Goal[] Goals { get; set; }
         /// <summary>
         /// The campaign's tiers.

--- a/src/Patreon.Net/Models/Member.cs
+++ b/src/Patreon.Net/Models/Member.cs
@@ -40,8 +40,14 @@ namespace Patreon.Net.Models
             Refunded,
             [EnumMember(Value = "Fraud")]
             Fraud,
+            [EnumMember(Value = "Refunded by Patreon")]
+            RefundedByPatreon,
             [EnumMember(Value = "Other")]
-            Other
+            Other,
+            [EnumMember(Value = "Partially Refunded")]
+            PartiallyRefunded,
+            [EnumMember(Value = "Free Trial")]
+            FreeTrial
         }
 
         /// <summary>
@@ -67,8 +73,18 @@ namespace Patreon.Net.Models
         /// <summary>
         /// The user is not a pledging patron but has subscribed to updates about public posts.
         /// </summary>
-        [JsonProperty("is_follower")]
-        public string IsFollower { get; set; }
+        [JsonProperty("is_follower"), Obsolete("This will always be false, following has been replaced by free membership.")]
+        public bool IsFollower { get; set; }
+        /// <summary>
+        /// Whether the user is in a free trial period.
+        /// </summary>
+        [JsonProperty("is_free_trial")]
+        public bool IsFreeTrial { get; set; }
+        /// <summary>
+        /// Whether the user's membership is from a free gift.
+        /// </summary>
+        [JsonProperty("is_gifted")]
+        public bool IsGifted { get; set; }
         /// <summary>
         /// The time of last attempted charge. Can be <see langword="null"/> if never charged.
         /// </summary>

--- a/src/Patreon.Net/Models/PledgeEvent.cs
+++ b/src/Patreon.Net/Models/PledgeEvent.cs
@@ -11,6 +11,21 @@ namespace Patreon.Net.Models
     /// </summary>
     public class PledgeEvent : PatreonResource<PledgeEventRelationships>
     {
+        public enum PledgePaymentStatusValue
+        {
+            [EnumMember(Value = "queued")]
+            Queued,
+            [EnumMember(Value = "pending")]
+            Pending,
+            [EnumMember(Value = "valid")]
+            Valid,
+            [EnumMember(Value = "declined")]
+            Declined,
+            [EnumMember(Value = "fraud")]
+            Fraud,
+            [EnumMember(Value = "disabled")]
+            Disabled
+        }
         [JsonConverter(typeof(StringEnumConverter))]
         public enum PaymentStatusValue
         {
@@ -26,8 +41,14 @@ namespace Patreon.Net.Models
             Refunded,
             [EnumMember(Value = "Fraud")]
             Fraud,
+            [EnumMember(Value = "Refunded by Patreon")]
+            RefundedByPatreon,
             [EnumMember(Value = "Other")]
-            Other
+            Other,
+            [EnumMember(Value = "Partially Refunded")]
+            PartiallyRefunded,
+            [EnumMember(Value = "Free Trial")]
+            FreeTrial
         }
 
         [JsonConverter(typeof(StringEnumConverter))]
@@ -61,17 +82,22 @@ namespace Patreon.Net.Models
         [JsonProperty("date")]
         public DateTimeOffset Date { get; set; }
         /// <summary>
+        /// The payment status of the pledge.
+        /// </summary>
+        [JsonProperty("pledge_payment_status")]
+        public PledgePaymentStatusValue PledgePaymentStatus { get; set; }
+        /// <summary>
         /// Status of underlying payment.
         /// </summary>
         [JsonProperty("payment_status")]
         public PaymentStatusValue PaymentStatus { get; set; }
         /// <summary>
-        /// Id of the tier associated with the pledge.
+        /// Id of the tier associated with the pledge. Can be <see langword="null"/>.
         /// </summary>
         [JsonProperty("tier_id")]
         public string TierId { get; set; }
         /// <summary>
-        /// Title of the reward tier associated with the pledge.
+        /// Title of the reward tier associated with the pledge. Can be <see langword="null"/>.
         /// </summary>
         [JsonProperty("tier_title")]
         public string TierTitle { get; set; }

--- a/src/Patreon.Net/Models/Tier.cs
+++ b/src/Patreon.Net/Models/Tier.cs
@@ -13,7 +13,7 @@ namespace Patreon.Net.Models
         /// Monetary amount associated with this tier (in U.S. cents).
         /// </summary>
         [JsonProperty("amount_cents")]
-        public string AmountCents { get; set; }
+        public int AmountCents { get; set; }
         /// <summary>
         /// The time this tier was created.
         /// </summary>

--- a/src/Patreon.Net/Models/User.cs
+++ b/src/Patreon.Net/Models/User.cs
@@ -35,6 +35,11 @@ namespace Patreon.Net.Models
         [JsonProperty("first_name")]
         public string FirstName { get; set; }
         /// <summary>
+        /// Last name. Can be <see langword="null"/>.
+        /// </summary>
+        [JsonProperty("last_name")]
+        public string LastName { get; set; }
+        /// <summary>
         /// Combined first and last name.
         /// </summary>
         [JsonProperty("full_name")]
@@ -54,11 +59,6 @@ namespace Patreon.Net.Models
         /// </summary>
         [JsonProperty("is_email_verified")]
         public bool IsEmailVerified { get; set; }
-        /// <summary>
-        /// Last name. Can be <see langword="null"/>.
-        /// </summary>
-        [JsonProperty("last_name")]
-        public string LastName { get; set; }
         /// <summary>
         /// How many posts this user has liked.
         /// </summary>
@@ -85,6 +85,10 @@ namespace Patreon.Net.Models
         /// </summary>
         [JsonProperty("vanity")]
         public string Vanity { get; set; }
+        /// <summary>
+        /// Whether or not this user has an active campaign.
+        /// </summary>
+        public bool IsCreator { get; set; }
     }
 
     public class UserRelationships

--- a/src/Patreon.Net/Patreon.Net.csproj
+++ b/src/Patreon.Net/Patreon.Net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Added `[Obsolete]` attribute to model fields that have been noted as deprecated in Patreon's developer documentation
- Updated models that were missing new fields & enum values returned by the API
- Updated Newtonsoft.Json dependency to latest stable version (13.0.3)
- Updated test program to check a few new properties
- Fixed outdated types in some models (some strings to their proper value types)
- Bumped project version to `1.0.3`